### PR TITLE
fix: This patch fixes this critical warning when registering MSDK:

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gst-plugins-bad1.0 (1.24.6-1deepin1) unstable; urgency=medium
+
+  *This patch fixes this critical warning when registering MSDK.
+
+ -- lichenggang <lichenggang@deepin.org>  Tue, 22 Oct 2024 16:13:02 +0800
+
 gst-plugins-bad1.0 (1.24.6-1) unstable; urgency=medium
 
   * New upstream version 1.24.6

--- a/debian/patches/fix-ill-format-string.patch
+++ b/debian/patches/fix-ill-format-string.patch
@@ -1,0 +1,30 @@
+From 236d6714ec7777dd83d8955ca188328369393283 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?V=C3=ADctor=20Manuel=20J=C3=A1quez=20Leal?=
+ <vjaquez@igalia.com>
+Date: Wed, 15 May 2024 12:48:43 +0200
+Subject: [PATCH] msdkcaps: fix ill-format string
+
+This patch fixes this critical warning when registering MSDK:
+
+_dma_fmt_to_dma_drm_fmts: assertion 'fmt != GST_VIDEO_FORMAT_UNKNOWN' failed
+
+It was because the HEVC string with possible output formats has an extra space
+that could not be parsed correctly.
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/6853>
+---
+ subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+
+--- gst-plugins-bad1.0-1.24.2.orig/sys/msdk/gstmsdkcaps.c
++++ gst-plugins-bad1.0-1.24.2/sys/msdk/gstmsdkcaps.c
+@@ -1745,7 +1745,7 @@ _dec_get_static_raw_formats (guint codec
+     case MFX_CODEC_AVC:
+       return "NV12, BGRA, BGRx";
+     case MFX_CODEC_HEVC:
+-      return "NV12, P010_10LE, YUY2, Y210,  VUYA, Y410, P012_LE, "
++      return "NV12, P010_10LE, YUY2, Y210, VUYA, Y410, P012_LE, "
+           "Y212_LE, Y412_LE, BGRA, BGRx";
+     case MFX_CODEC_MPEG2:
+       return "NV12";

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 02_opencv-data-path.patch
 Skip-failing-tests.patch
+fix-ill-format-string.patch


### PR DESCRIPTION
  _dma_fmt_to_dma_drm_fmts: assertion 'fmt != GST_VIDEO_FORMAT_UNKNOWN' failed

It was because the HEVC string with possible output formats has an extra space that could not be parsed correctly.