### PR TITLE
fix CVE-2026-3082: jpegparser: boundary checks before copying it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Build
 
 # hotdoc
 docs/hotdoc/libs/generated_sitemap.txt
+
+.cve-fixer/

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gst-plugins-bad1.0 (1.24.6-1deepin5) unstable; urgency=medium
+
+  * fix CVE-2026-3082
+
+ -- lichenggang <lichenggang@uniontech.com>  Tue, 07 Apr 2026 10:26:24 +0800
+
 gst-plugins-bad1.0 (1.24.6-1deepin4) unstable; urgency=medium
 
   * fix CVE-2026-2923 

--- a/debian/patches/CVE-2026-3082.patch
+++ b/debian/patches/CVE-2026-3082.patch
@@ -1,0 +1,41 @@
+From 83e9225bb9e89948e7b1c9f37ef9218d2dcde354 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?V=C3=ADctor=20Manuel=20J=C3=A1quez=20Leal?=
+ <vjaquez@igalia.com>
+Date: Wed, 11 Feb 2026 22:07:49 +0100
+Subject: [PATCH] libs: jpegparser: boundary checks before copying it
+
+READ_BYTES macro reads data from a byte reader and then copy it to a storage
+variable. This patch adds a validation that the length to read cannot be bigger
+than the storage size.
+
+This macro right now is used only for storage variables of guint8 arrays.
+
+We have validated in the specification (sections F.1.2.1.2 and F.1.2.2.1 in ITU
+T.81) that Huffman tables (both AC and DC) aren't bigger than 256.
+
+Fixes SA-2026-0003, CVE-2026-3082, ZDI-CAN-28840.
+
+Fixes: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/4899>
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10946>
+---
+ .../gst-plugins-bad/gst-libs/gst/codecparsers/gstjpegparser.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gstjpegparser.c b/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gstjpegparser.c
+index 64110763f21..86125b3747e 100644
+--- a/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gstjpegparser.c
++++ b/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gstjpegparser.c
+@@ -79,6 +79,10 @@ ensure_debug_category (void)
+ 
+ #define READ_BYTES(reader, buf, length) G_STMT_START {          \
+     const guint8 *vals;                                         \
++    if (length > sizeof (buf)) {                                \
++      GST_WARNING ("data size is bigger than its storage");     \
++      goto failed;                                              \
++    }                                                           \
+     if (!gst_byte_reader_get_data (reader, length, &vals)) {    \
+       GST_WARNING ("failed to read bytes, size:%d", length);    \
+       goto failed;                                              \
+-- 
+GitLab
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ fix-ill-format-string.patch
 CVE-2026-2923-1.patch
 CVE-2026-2923-2.patch
 CVE-2026-2923-3.patch
+CVE-2026-3082.patch


### PR DESCRIPTION
修复 CVE-2026-3082：GStreamer JPEG Parser 堆缓冲区溢出漏洞。

上游补丁：https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/83e9225bb9e89948e7b1c9f37ef9218d2dcde354

在 READ_BYTES 宏中添加长度校验，确保读取的数据长度不会超过存储缓冲区的大小，防止堆缓冲区溢出。